### PR TITLE
Various fixes to address errors, warnings, clarity, support macOS and to address deprecation warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ tests/
 
 # Miscellaneous files
 .DS_Store
+
+# Ignore the secrets file
+/terraform/vmseries/secrets.auto.tfvars

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This code helps deploy all the resources required to successfully demonstrate th
 - Permissions to subscribe to VM-Series on the AWS Marketplace.
 - Permissions to deploy all networking resources like VPC, Subnets, etc.
 - Permissions to deploy EC2 instances and connect to them via SSH.
+- Five (5) available Elastic IP in your quota (by default, accounts have a quota of 5, if you're using any separate from this lab, you'll need to increase your quote before running this).
+- If running from a local workspace, either a macOS or GNU Linux environment is required (alternatively, you can use AWS CloudShell).
+- If on macOS, Homebrew installed.
 
 ## Demo Lab Setup
 
@@ -17,7 +20,9 @@ In this section, we will launch the lab environment. These are the steps that we
 - Login to the AWS Console using the provided credentials and set up IAM roles
 - Subscribe to the Palo Alto Networks VM-Series PAYG on the AWS Marketplace.
    - You can follow this link to open the Marketplace page directly. On the page that opens up, Click on “Continue to Subscribe” and then Click on “Accept Terms”.<br/>https://aws.amazon.com/marketplace/pp?sku=hd44w1chf26uv4p52cdynb2o
-- Deploy lab environment using Terraform
+- If you do not have room for 4 more Elastic IPs, request an increase in the Elastic IP service quota to add 5 more. ([In the service quotas, under EC2](https://us-east-1.console.aws.amazon.com/servicequotas/home/services/ec2/quotas), search for "EC2-VPC Elastic IPs".)
+- Create a new SSH key pair in the AWS console. Enter the name of they key in the environment variables below.
+- Deploy lab environment using Terraform (via the setup.sh script).
 
 ### Cloning the Git Repo
 
@@ -35,6 +40,7 @@ If you are attempting to deploy from your local workspace, you would need to upd
 ```
 access-key      = ""
 secret-key      = ""
+session-token   = ""
 region          = ""
 ssh-key-name    = ""
 ```
@@ -43,7 +49,9 @@ In case you are using AWS CloudShell, you can ignore this step.
 
 ### Run the setup
 
-Once you have completed the above steps as required, ensure that you are in the root directory of the cloned repo and run the below command.
+Once you have completed the above steps as required, ensure that you are in the root directory of the cloned repo and run the below command. 
+
+> **NOTE:** Running this script WILL INSTALL other dependencies!
 
 ```
 ./setup.sh
@@ -54,6 +62,7 @@ It will take around 5 minutes to deploy all the lab components. Status will be u
 ## Demo Lab Teardown
 
 Ensure that you have the permissions to delete all the resources that were created as part of the setup. Adjust the "cd" command below to change the directory as required.
+
 Run the below commands to teardown the setup.
 
 ```
@@ -61,9 +70,29 @@ cd ~/aws-vmseries-gwlb-poc/terraform/vmseries
 terraform destroy -auto-approve
 ```
 
+## Connecting to the Palo Alto Networks VM-Series Firewall
+
+Before connecting to the web console of the Palo Alto Networks VM-Series Firewall, you need to set up the password for the admin user. You can do this by connecting to the firewall using SSH and running the below command.
+
+1. ssh to the ip address of the firewall (from the terraform output) `ssh -i /path/to/ssh-key.pem admin@<firewall-ip>`
+2. Run the below command to set the password for the admin user.
+
+```bash
+set mgt-config users admin password
+```
+
+After an admin password is set, you can access the web interface at https://<firewall-ip> with the username as "admin" and the password that you set.
+
+# TODO: Explain better how to use the Firewall web interface for verifying the configuration.
+
 ## Connecting to the app servers
 
-We will be using the user ‘ec2-user’ as the username to login to these applications.
+We will be using the user ‘ec2-user’ as the username to login to these applications. Use the SSH key that you provided in the environment variables.
+
+You can also verify the app server (vulnerable web server) are up with:
+http://<elastic-ip>:8080 (vulnerable web server)
+
+# TODO: Explain better the role of the "Attack" and "Vulnerable" servers and how to test with them.
 
 ### On the AWS CloudShell
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,45 @@
+#!/bin/bash
 
+# Function to verify if Homebrew is installed on MacOS, if not, then install Homebrew
+function verify_macos_homebrew() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macOS detected. Verifying if Homebrew is installed..."
+        if ! command -v brew &> /dev/null; then
+            echo "Homebrew is not installed. Exiting with error. Install Homebrew and re-run the script."
+            exit 1
+        else
+            echo "Homebrew confirmed."
+        fi
+    fi
+}
+
+# Function to install the prerequisites required for the deployment of the
+# AWS Zero Trust Reference Architecture with VM-Series on AWS
 function install_prerequisites() {
-    sudo yum install -y jq
-    sudo yum install -y wget
+  echo "Verifying prerequisites..."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+      if ! brew list jq &>/dev/null; then
+          brew install jq
+      else
+          echo "jq is already installed."
+      fi
+      if ! brew list wget &>/dev/null; then
+          brew install wget
+      else
+          echo "wget is already installed."
+      fi
+  elif [[ "$OSTYPE" == "linux-gnu" ]]; then
+      if ! command -v jq &>/dev/null; then
+          sudo yum install -y jq
+      else
+          echo "jq is already installed."
+      fi
+      if ! command -v wget &>/dev/null; then
+          sudo yum install -y wget
+      else
+          echo "wget is already installed."
+      fi
+  fi
 }
 
 # Function to check if Terraform is installed already, if not, then download and installed the version of Terraform as required.
@@ -12,22 +50,37 @@ function install_terraform() {
     # Check if terraform is already installed and display the version of terraform as installed
     [[ -f ${HOME}/bin/terraform ]] && echo "`${HOME}/bin/terraform version` already installed at ${HOME}/bin/terraform" && return 0
 
-    TERRAFORM_DOWNLOAD_URL=$(curl -sL https://releases.hashicorp.com/terraform/index.json | jq -r '.versions[].builds[].url' | egrep 'linux.*amd64' | egrep "${TERRAFORM_VERSION}" | egrep -v 'rc|beta|alpha')
-    TERRAFORM_DOWNLOAD_FILE=$(basename $TERRAFORM_DOWNLOAD_URL)
-
-    echo "Downloading Terraform v$TERRAFORM_VERSION from '$TERRAFORM_DOWNLOAD_URL'"
-
-    # Download and install Terraform v1.1.7 as that is the version used for the development of this code-base.
-    # TODO: Once Base and Ceiling versions have been validated, the code here will be modified to download the Ceiling version of terraform as required by the scripts in this code-base.
-    mkdir -p ${HOME}/bin/ && cd ${HOME}/bin/ && wget $TERRAFORM_DOWNLOAD_URL && unzip $TERRAFORM_DOWNLOAD_FILE && rm $TERRAFORM_DOWNLOAD_FILE
-
-    # Display an confirmation of the successful installation of Terraform.
-    echo "Installed: `${HOME}/bin/terraform version`"
+    # if macOS, we want to use brew to install tfenv (terraform version  manager)
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v tfenv &> /dev/null; then
+          echo "tfenv is installed."
+        else
+          echo "Installing tfenv..."
+          brew install tfenv
+        fi
+        if tfenv list | grep -q $TERRAFORM_VERSION; then
+          echo "Terraform version $TERRAFORM_VERSION is already installed."
+        else
+          echo "Installing Terraform version $TERRAFORM_VERSION..."
+          tfenv install $TERRAFORM_VERSION
+        fi
+        tfenv use $TERRAFORM_VERSION
+    elif [[ "$OSTYPE" == "linux-gnu" ]]; then
+      # Else, download and install Terraform v1.1.7 for GNU Linux
+      TERRAFORM_DOWNLOAD_URL=$(curl -sL https://releases.hashicorp.com/terraform/index.json | jq -r '.versions[].builds[].url' | egrep 'linux.*amd64' | egrep "${TERRAFORM_VERSION}" | egrep -v 'rc|beta|alpha')
+      TERRAFORM_DOWNLOAD_FILE=$(basename $TERRAFORM_DOWNLOAD_URL)
+      echo "Downloading Terraform v$TERRAFORM_VERSION from '$TERRAFORM_DOWNLOAD_URL'"
+      # Download and install Terraform v1.1.7 as that is the version used for the development of this code-base.
+      # TODO: Once Base and Ceiling versions have been validated, the code here will be modified to download the Ceiling version of terraform as required by the scripts in this code-base.
+      mkdir -p ${HOME}/bin/ && cd ${HOME}/bin/ && wget $TERRAFORM_DOWNLOAD_URL && unzip $TERRAFORM_DOWNLOAD_FILE && rm $TERRAFORM_DOWNLOAD_FILE
+          # Display an confirmation of the successful installation of Terraform.
+      echo "Installed: `${HOME}/bin/terraform version`"
+    fi
 }
 
 function deploy_vmseries_lab() {
     # Assuming that this setup script is being run from the cloned github repo, changing the current working directory to one from where Terraform will deploy the lab resources.
-    cd "${HOME}/aws-vmseries-gwlb-poc/terraform/vmseries"
+    cd "./terraform/vmseries" || Echo "./terraform/vmseries not found! Exiting." && exit 1
 
     # Initialize terraform
     echo "Initializing directory for lab resource deployment"
@@ -45,6 +98,7 @@ function deploy_vmseries_lab() {
     fi
 }
 
+verify_macos_homebrew
 install_prerequisites
 install_terraform
 deploy_vmseries_lab

--- a/terraform/modules/vm-series/main.tf
+++ b/terraform/modules/vm-series/main.tf
@@ -39,7 +39,6 @@ resource "random_string" "randomstring" {
 
 resource "aws_s3_bucket" "bootstrap_bucket_ngfw" {
   bucket        = "${join("", tolist(["aws-gwlb-vm-series-bootstrap", "-", random_string.randomstring.result]))}"
-  acl           = "private"
   force_destroy = true
 }
 
@@ -53,37 +52,32 @@ resource "aws_vpc_endpoint_route_table_association" "s3" {
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
 }
 
-resource "aws_s3_bucket_object" "bootstrap_xml" {
+resource "aws_s3_object" "bootstrap_xml" {
   bucket = aws_s3_bucket.bootstrap_bucket_ngfw.id
-  acl    = "private"
   key    = "config/bootstrap.xml"
   source = "../modules/bootstrap_files/bootstrap.xml"
 }
 
-resource "aws_s3_bucket_object" "init-cft_txt" {
+resource "aws_s3_object" "init_cft_txt" {
   bucket = aws_s3_bucket.bootstrap_bucket_ngfw.id
-  acl    = "private"
   key    = "config/init-cfg.txt"
   source = "../modules/bootstrap_files/init-cfg.txt"
 }
 
-resource "aws_s3_bucket_object" "software" {
+resource "aws_s3_object" "software" {
   bucket = aws_s3_bucket.bootstrap_bucket_ngfw.id
-  acl    = "private"
   key    = "software/"
   source = "/dev/null"
 }
 
-resource "aws_s3_bucket_object" "license" {
+resource "aws_s3_object" "license" {
   bucket = aws_s3_bucket.bootstrap_bucket_ngfw.id
-  acl    = "private"
   key    = "license/authcodes"
   source = "/dev/null"
 }
 
-resource "aws_s3_bucket_object" "content" {
+resource "aws_s3_object" "content" {
   bucket = aws_s3_bucket.bootstrap_bucket_ngfw.id
-  acl    = "private"
   key    = "content/"
   source = "/dev/null"
 }

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -152,10 +152,7 @@ data "aws_ami" "latest_ecs" {
 }
 
 data "aws_key_pair" "key_name" {
-  filter {
-    name = "key-name"
-    values = ["qwikLABS-*"]
-  }
+  key_name = var.ssh-key-name
 }
 
 resource "aws_network_interface" "private" {

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -8,3 +8,5 @@ variable "ec2-instances" { default = [] }
 variable "prefix-name-tag" { default = "" }
 variable "global_tags" { default = {} }
 variable "nat_gateways" { default = {} }
+
+variable "ssh-key-name" { default = "" }

--- a/terraform/vmseries/student.auto.tfvars
+++ b/terraform/vmseries/student.auto.tfvars
@@ -1,13 +1,12 @@
-############################################################
-# Make sure to fill in the values for access-key, secret-key
-# and region before running the terraform.
-############################################################
-access-key      = ""
-secret-key      = ""
-region          = ""
-ssh-key-name    = ""                        # Update this as "qwikLABS-*" if deploying this on QwikLabs portal.
+# Create a file "secrets.auto.tfvars" with the below and fill in the values for access-key, secret-key and region
+# before running the terraform.
+# access-key      = ""
+# secret-key      = ""
+# session-token   = ""
+# region          = ""
+# ssh-key-name    = ""                        # Update this as "qwikLABS-*" if deploying this on QwikLabs portal.
 
-prefix-name-tag     = "demo-"               # Feel free to modify this if required. This prefix is just meant to make the lab resources identifiable
+prefix-name-tag     = "palo-poc-"               # Feel free to modify this if required. This prefix is just meant to make the lab resources identifiable
 global_tags         = {
   # The tags added below are specific to Palo Alto Networks. You can modify the tags as applicable for your use-case.
   managedBy   = "Terraform"

--- a/terraform/vmseries/variables.tf
+++ b/terraform/vmseries/variables.tf
@@ -45,4 +45,6 @@ variable "prefix-name-tag"  { default = "" }
 variable "global_tags"      { default = {} }
 variable "access-key"       { default = "" }
 variable "secret-key"       { default = "" }
+variable "session-token"    { default = "" }
 variable "region"           { default = "" }
+variable "ssh-key-name"     { default = "" }

--- a/terraform/vmseries/versions.tf
+++ b/terraform/vmseries/versions.tf
@@ -9,7 +9,8 @@ terraform {
 }
 
 provider "aws" {
-  # access_key = var.access-key
-  # secret_key = var.secret-key
-  # region     = var.region
+  access_key = var.access-key
+  secret_key = var.secret-key
+  token      = var.session-token
+  region     = var.region
 }


### PR DESCRIPTION
## Description

* Separates secrets into a secrets.auto.tfvars file that can be excluded from source. Excludes secrets in gitignore.
* Edits the student.auto.tfvars to make a reference to the secrets and to remove the actual variable declarations.
* Fixes syntax issues with ACL in S3 buckets (acl is deprecated).
* Fixes syntax error when pulling the ssh key using name.
* Adds more dependencies into the readme: explanation of needing to have Elastic IP quota available; explanation on setting the password for the PALO web interface; explanation on how to verify the app servers are up and to connect to them; adds sesion-token to the secrets in readme, which is required in certain environments.
* Adds support in setup.sh for macOS.
* variables.tf adds support for ssh-key-name to avoid runtime error.
* variables.tf adds session-token.
* 
## Motivation and Context

Adds support fort macOS and corrects a few warnings and errors.
There is no open issue related to this.

## How Has This Been Tested?

Tested against a multi-account AWS tenant. All resources created correctly and referenced the right values per the changes. Ran the updated setup script from macOS and verified functionality.

Did not test in LINUX, but the changes were done using CONDITIONALS so the Linux code is the same.

## Screenshots (if appropriate)

N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
  - Deprecation warnings around S3 ACLs
  - Errors related to pulling the ssh key name by name 
- New feature (non-breaking change which adds functionality)
  - Support for running the Terraform under macOS 
- Breaking change (fix or feature that would cause existing functionality to change)
  - None 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [n/a] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes if appropriate.
- [ n/a] All new and existing tests passed.
